### PR TITLE
Upgrade to cats 1.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val catsCheckSettings = Seq(
     "org.scalacheck" %%% "scalacheck" % "1.13.5",
     "org.typelevel" %%% "cats-core" % catsVersion,
     "org.typelevel" %%% "cats-laws" % catsVersion % "test",
-    "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
+    "org.scalatest" %%% "scalatest" % "3.0.4" % "test",
     "org.typelevel" %%% "discipline" % "0.8" % "test"
   ),
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import ReleaseTransformations._
 
-val catsVersion = "0.9.0"
+val catsVersion = "1.0.1"
 
 lazy val catsCheckSettings = Seq(
   organization := "org.mdedetrich",
@@ -18,10 +18,10 @@ lazy val catsCheckSettings = Seq(
 
   libraryDependencies ++= Seq(
     "org.scalacheck" %%% "scalacheck" % "1.13.4",
-    "org.typelevel" %%% "cats" % catsVersion,
+    "org.typelevel" %%% "cats-core" % catsVersion,
     "org.typelevel" %%% "cats-laws" % catsVersion % "test",
     "org.scalatest" %%% "scalatest" % "3.0.0" % "test",
-    "org.typelevel" %%% "discipline" % "0.7.3"      % "test"
+    "org.typelevel" %%% "discipline" % "0.8" % "test"
   ),
 
   releaseCrossBuild := true,

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ lazy val catsCheckSettings = Seq(
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
   homepage := Some(url("http://github.com/mdedetrich/cats-check")),
 
-  scalaVersion := "2.12.1",
-  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1"),
+  scalaVersion := "2.12.4",
+  crossScalaVersions := Seq("2.10.7", "2.11.12", scalaVersion.value),
 
   scalacOptions ++= Seq(
     "-feature",

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ lazy val catsCheckSettings = Seq(
     publishArtifacts,
     setNextVersion,
     commitNextVersion,
-    ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
+    releaseStepCommand("sonatypeReleaseAll"),
     pushChanges))
 
 lazy val noPublish = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val catsCheckSettings = Seq(
   ),
 
   libraryDependencies ++= Seq(
-    "org.scalacheck" %%% "scalacheck" % "1.13.4",
+    "org.scalacheck" %%% "scalacheck" % "1.13.5",
     "org.typelevel" %%% "cats-core" % catsVersion,
     "org.typelevel" %%% "cats-laws" % catsVersion % "test",
     "org.scalatest" %%% "scalatest" % "3.0.0" % "test",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.0.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.0")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "0.5.0")
-addSbtPlugin("org.scala-js"      % "sbt-scalajs"  % "0.6.14")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.1.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.7")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "2.1")
+addSbtPlugin("org.scala-js"      % "sbt-scalajs"  % "0.6.22")

--- a/src/main/scala/catscheck/instances/cogen.scala
+++ b/src/main/scala/catscheck/instances/cogen.scala
@@ -4,9 +4,7 @@ package instances
 import scala.language.higherKinds
 
 import cats._
-import cats.implicits._
 
-import functor.Contravariant
 import rng.Seed
 
 object cogen extends CogenInstances {
@@ -38,8 +36,8 @@ object cogen extends CogenInstances {
 }
 
 trait CogenInstances {
-  implicit val cogenContravariantCartesian: ContravariantCartesian[Cogen] =
-    new ContravariantCartesian[Cogen] {
+  implicit val cogenContravariantSemigroupal: ContravariantSemigroupal[Cogen] =
+    new ContravariantSemigroupal[Cogen] {
       def contramap[A, B](c: Cogen[A])(f: B => A): Cogen[B] =
         c.contramap(f)
       def product[A, B](ca: Cogen[A], cb: Cogen[B]): Cogen[(A, B)] =

--- a/src/test/scala/catscheck/instances/Laws.scala
+++ b/src/test/scala/catscheck/instances/Laws.scala
@@ -1,14 +1,12 @@
 package org.scalacheck
 package instances
 
-import scala.util.{Failure, Success, Try}
-
 import cats.Eq
 import cats.data.NonEmptyList
 import cats.implicits._
 
 import org.scalatest.{FunSuite, Matchers}
-import org.scalatest.prop.{Configuration, PropertyChecks}
+import org.scalatest.prop.PropertyChecks
 import org.typelevel.discipline.scalatest.Discipline
 
 import org.scalacheck.Arbitrary.arbitrary
@@ -21,12 +19,12 @@ class CatsCheckLaws extends FunSuite
     with Discipline
     with Setup {
 
-  checkAll("Gen", cats.laws.discipline.MonadCombineTests[Gen].monadCombine[Int, Int, Int])
-  checkAll("Gen[String]", cats.kernel.laws.GroupLaws[Gen[String]].monoid)
-  checkAll("Gen[NonEmptyList[Int]]", cats.kernel.laws.GroupLaws[Gen[NonEmptyList[Int]]].semigroup)
+  checkAll("Gen", cats.laws.discipline.AlternativeTests[Gen].alternative[Int, Int, Int])
+  checkAll("Gen[String]", cats.kernel.laws.discipline.MonoidTests[Gen[String]].monoid)
+  checkAll("Gen[NonEmptyList[Int]]", cats.kernel.laws.discipline.SemigroupTests[Gen[NonEmptyList[Int]]].semigroup)
 
   checkAll("Cogen", cats.laws.discipline.ContravariantTests[Cogen].contravariant[Int, Int, Int])
-  checkAll("Cogen", cats.laws.discipline.CartesianTests[Cogen].cartesian[Int, Int, Int])
+  checkAll("Cogen", cats.laws.discipline.SemigroupalTests[Cogen].semigroupal[Int, Int, Int])
   checkAll("Cogen", cats.laws.discipline.MonoidKTests[Cogen].monoidK[Int])
 }
 
@@ -45,7 +43,7 @@ trait Setup {
     Cogen[Long].contramap(_.long._1)
 
   implicit def arbitraryNonEmptyList[A: Arbitrary]: Arbitrary[NonEmptyList[A]] =
-    Arbitrary((arbitrary[A], arbitrary[List[A]]).map2(NonEmptyList(_, _)))
+    Arbitrary(for {x <- arbitrary[A]; xs <- arbitrary[List[A]]} yield NonEmptyList(x, xs))
 
   // scalacheck's built-in Arbitrary[Gen[A]] is not great.
   implicit def arbitraryGen[A: Arbitrary]: Arbitrary[Gen[A]] = {


### PR DESCRIPTION
I'm not sure about the `MonadCombine` -> `Alternative` transition as this was mostly guesswork for me. I took it from the cats changelog but am not confident that `Alternative` is an adequate replacement for `MonadCombine`.